### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,22 +6,22 @@
 # Datatypes (KEYWORD1)
 ###############################################
 
-TimeSet         KEYWORD1        SunSimulation
-SunSimulation   KEYWORD1        SunSimulation
+TimeSet	KEYWORD1	SunSimulation
+SunSimulation	KEYWORD1	SunSimulation
 
 ###############################################
 # Methods and Functions (KEYWORD2)
 ###############################################
-getHour                 KEYWORD2
-getMinute               KEYWORD2
-getDuration             KEYWORD2
-regimenInit             KEYWORD2
-reloadRegimen           KEYWORD2
-changeBrightness        KEYWORD2
+getHour	KEYWORD2
+getMinute	KEYWORD2
+getDuration	KEYWORD2
+regimenInit	KEYWORD2
+reloadRegimen	KEYWORD2
+changeBrightness	KEYWORD2
 
 ###############################################
 # Constants (LITERAL1)
 ###############################################
-START_RISE              LITERAL1
-PWM_MAX                 LITERAL1
-DAY_SECONDS             LITERAL1
+START_RISE	LITERAL1
+PWM_MAX	LITERAL1
+DAY_SECONDS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords